### PR TITLE
fixed the booking form page reloading issue any time a new property or vendor gets added

### DIFF
--- a/src/components/AddNewPropertyForm/AddNewPropertyForm.jsx
+++ b/src/components/AddNewPropertyForm/AddNewPropertyForm.jsx
@@ -41,7 +41,7 @@ const AddNewPropertyForm = ({modalVisible, onClose}) => {
         );
     };
 
-    const onSubmit = () => {
+    const onSubmit = (event) => {
         event.preventDefault();
         let propertyAddress = {
             address,
@@ -62,7 +62,7 @@ const AddNewPropertyForm = ({modalVisible, onClose}) => {
         setCity('');
         setState('');
         setZipCode('');
-        history.push('/bookingform');
+        onClose();
     };
 
     return ReactDOM.createPortal(

--- a/src/components/AddNewVendorForm/AddNewVendorForm.jsx
+++ b/src/components/AddNewVendorForm/AddNewVendorForm.jsx
@@ -30,14 +30,15 @@ const AddNewVendorForm = ({ modalVisible, onClose }) => {
         }
     };
 
-    const onSubmit = () => {
+    const onSubmit = (event) => {
         event.preventDefault();
         dispatch({
             type: 'POST_NEW_VENDOR',
             payload: {vendorName}
         });
         setVendorName('');
-        history.goBack();
+        onClose();
+        return false;
     };
 
     return ReactDOM.createPortal(

--- a/src/components/BookingForm/BookingForm.jsx
+++ b/src/components/BookingForm/BookingForm.jsx
@@ -40,13 +40,15 @@ const BookingForm = () => {
     const [netPayout, setNetPayout] = useState(0);
     const [petFees, setPetFees] = useState('');
     const [phone, setPhone] = useState('');
+    const [propertyAdded, SetPropertyAdded] = useState(false);
     const [propertyId, setPropertyId] = useState(1);
     const propertyList = useSelector((store) => store.propertyList);
     const [propertyModalVisible, setPropertyModalVisible] = useState(false);
     const [rentalCost, setRentalCost] = useState(0);
     const [submitDisabled, setSubmitDisabled] = useState(true);
     const taxResponsibility = useSelector((store) => store.taxResponsibility);
-    const [vendor, setVendor] = useState('AirBNB');
+    const [vendor, setVendor] = useState('Airbnb');
+    const [vendorAdded, setVendorAdded] = useState(false);
     const [vendorCommissions, setVendorCommissions] = useState('');
     const [vendorFees, setVendorFees] = useState('');
     const [vendorModalVisible, setVendorModalVisible] = useState(false);
@@ -56,6 +58,14 @@ const BookingForm = () => {
         dispatch({type: 'GET_VENDORS'});
         dispatch({type: 'GET_PROPERTIES'});
     }, []);
+
+    useEffect(() => {
+        dispatch({type: 'GET_VENDORS'});
+    }, [vendorAdded]);
+
+    useEffect(() => {
+        dispatch({type: 'GET_PROPERTIES'});
+    }, [propertyAdded]);
     
     useEffect(() => {
         checkFormComplete();
@@ -114,7 +124,7 @@ const BookingForm = () => {
         }
     };              
 
-    const onSubmit = () => {
+    const onSubmit = (event) => {
         event.preventDefault();
         dispatch({
             type: 'POST_BOOKING',
@@ -158,7 +168,9 @@ const BookingForm = () => {
     };
 
     return (
-        <div className="booking-form-container">  
+        <div className="booking-form-container">
+            <AddNewVendorForm modalVisible={vendorModalVisible} onClose={() => {setVendorModalVisible(false); setVendorAdded(!vendorAdded)}}/>  
+            <AddNewPropertyForm modalVisible={propertyModalVisible} onClose={() => {setPropertyModalVisible(false); SetPropertyAdded(!propertyAdded)}}/>
             <form key="booking-form" onSubmit={onSubmit}>
                 <section className="required">* indicates required fields</section>
                 
@@ -176,7 +188,6 @@ const BookingForm = () => {
                         })}
                     </select>
                     <button type="button" className="add-property-btn" onClick={() => setPropertyModalVisible(true)}>+</button>
-                    <AddNewPropertyForm modalVisible={propertyModalVisible} onClose={() => setPropertyModalVisible(false)}/>
                 </div>
 
                 <div className="section-header">
@@ -275,8 +286,6 @@ const BookingForm = () => {
                     {(checkOut < checkIn && checkOut != null && checkIn != null) &&
                         <h3 className="alert" role="alert">Check-out date must come after check-in date!</h3>
                     }
-
-                    {/* try to find way to check if dates are the same */}
 
                 </div> {/* end of tenant-input-date-div */}
 
@@ -384,7 +393,6 @@ const BookingForm = () => {
                                 })}          
                             </select>
                             <button type="button" className="add-vendor-btn" onClick={() => setVendorModalVisible(true)}>+</button>
-                            <AddNewVendorForm modalVisible={vendorModalVisible} onClose={() => setVendorModalVisible(false)}/>
                         </div>
                     }
 

--- a/src/redux/sagas/vendor.saga.js
+++ b/src/redux/sagas/vendor.saga.js
@@ -5,7 +5,7 @@ function* getVendors() {
   try {
       const vendors = yield axios.get(`/api/vendor`);
       yield put({ type: 'SET_VENDORS', payload: vendors.data});
-      console.log('in vendor saga with db data: ', vendors.data)
+      console.log('in vendor saga with db data: ', vendors.data);
   } catch (error) {
     console.log('error getting vendors', error);
   }


### PR DESCRIPTION
Solution - moved the modal content outside of the Form tags and added 2 useStates - 1 to keep track of a newly added vendor and 1 to keep track of a newly added property. 
Then added useffects which are dependent on those two values changing. When those values change, the appropriate get request is fired off and updates the array list without refreshing the entire booking form page, keeping any data in the inputs in tact.